### PR TITLE
Load store instructions

### DIFF
--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -704,7 +704,17 @@ pub mod instructions {
 
         1
     }
-    pub fn strbt(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Store register byte with translation
+    pub fn strbt(emulator: &mut Emulator, instruction: u32) -> u32 {
+        /*
+        processor_id = ExecutingProcessor()
+        if ConditionPassed(cond) then
+            Memory[address,1] = Rd[7:0]
+        */
+
+        load_store_instruction_wrapper(emulator, instruction, store_register_byte);
+
         1
     }
 

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -562,7 +562,23 @@ pub mod instructions {
 
         1
     }
-    pub fn ldrbt(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Load register byte with translation
+    pub fn ldrbt(emulator: &mut Emulator, instruction: u32) -> u32 {
+        /*
+        if ConditionPassed(cond) then
+            Rd = Memory[address,1]
+            Rn = address
+        */
+
+        debug_assert_ne!(
+            RegisterNames::try_from(instruction >> 12 & 0xf).unwrap(),
+            r15,
+            "LDRBT: result is unpredictable if r15 is specified for destination register"
+        );
+
+        load_store_instruction_wrapper(emulator, instruction, load_register_byte);
+
         1
     }
 

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -597,7 +597,20 @@ pub mod instructions {
 
         1
     }
-    pub fn ldrsh(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Load register signed halfword
+    pub fn ldrsh(emulator: &mut Emulator, instruction: u32) -> u32 {
+        misc_load_store_instruction_wrapper(
+            emulator,
+            instruction,
+            |emulator, destination_register, address| {
+                let value = (read_half_word(emulator, address) as i32) << 16 >> 16;
+                emulator
+                    .cpu
+                    .set_register_value(destination_register, value as u32);
+            },
+        );
+
         1
     }
     pub fn ldrt(_emulator: &mut Emulator, _instruction: u32) -> u32 {

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -269,6 +269,7 @@ mod internal {
 /// instructions.
 pub mod instructions {
     use crate::emulator::{
+        armv4t::arm::internal::*,
         armv4t::utils::*,
         cpu::{RegisterNames::*, *},
         Emulator,
@@ -667,7 +668,19 @@ pub mod instructions {
     pub fn strbt(_emulator: &mut Emulator, _instruction: u32) -> u32 {
         1
     }
-    pub fn strh(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Store half-word
+    pub fn strh(emulator: &mut Emulator, instruction: u32) -> u32 {
+        misc_load_store_instruction_wrapper(
+            emulator,
+            instruction,
+            |emulator, source_register, address| {
+                let value = emulator.cpu.get_register_value(source_register) & 0xffff;
+
+                write_half_word(emulator, address, value as u16);
+            },
+        );
+
         1
     }
     pub fn strt(_emulator: &mut Emulator, _instruction: u32) -> u32 {

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -722,9 +722,21 @@ pub mod instructions {
 
         1
     }
-    pub fn strt(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Store register with translation
+    pub fn strt(emulator: &mut Emulator, instruction: u32) -> u32 {
+        /*
+        MemoryAccess(B-bit, E-bit)
+        processor_id = ExecutingProcessor()
+        if ConditionPassed(cond) then
+            Memory[address,4] = Rd
+        */
+
+        load_store_instruction_wrapper(emulator, instruction, store_register);
+
         1
     }
+
     pub fn sub(_emulator: &mut Emulator, _instruction: u32) -> u32 {
         1
     }

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -161,14 +161,14 @@ mod internal {
         emulator.memory.write_word(address, value);
     }
 
+    // Main bits of the load/store instructions, these are used in both the normal instructions and
+    // in the with translation instructions.
     pub fn store_register(emulator: &mut Emulator, source_register: RegisterNames, address: u32) {
         let source_register_value = emulator.cpu.get_register_value(source_register);
 
         write_word(emulator, address & 0xFFFF_FFFC, source_register_value);
     }
 
-    // Main bits of the load/store instructions, these are used in both the normal instructions and
-    // in the with translation instructions.
     pub fn store_register_byte(
         emulator: &mut Emulator,
         source_register: RegisterNames,
@@ -584,7 +584,17 @@ pub mod instructions {
 
         1
     }
-    pub fn strb(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Store register byte
+    pub fn strb(emulator: &mut Emulator, instruction: u32) -> u32 {
+        /*
+        processor_id = ExecutingProcessor()
+        if ConditionPassed(cond) then
+            Memory[address,1] = Rd[7:0]
+        */
+
+        load_store_instruction_wrapper(emulator, instruction, store_register_byte);
+
         1
     }
     pub fn strbt(_emulator: &mut Emulator, _instruction: u32) -> u32 {

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -200,6 +200,17 @@ mod internal {
         }
     }
 
+    pub fn load_register_byte(
+        emulator: &mut Emulator,
+        destination_register: RegisterNames,
+        address: u32,
+    ) {
+        let value = emulator.memory.read_byte(address);
+        emulator
+            .cpu
+            .set_register_value(destination_register, value as u32);
+    }
+
     pub fn load_store_instruction_wrapper(
         emulator: &mut Emulator,
         instruction: u32,
@@ -510,7 +521,16 @@ pub mod instructions {
         5
     }
 
-    pub fn ldrb(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+    /// Load register byte
+    pub fn ldrb(emulator: &mut Emulator, instruction: u32) -> u32 {
+        /*
+        MemoryAccess(B-bit, E-bit)
+        if ConditionPassed(cond) then
+            Rd = Memory[address,1]
+        */
+
+        load_store_instruction_wrapper(emulator, instruction, load_register_byte);
+
         1
     }
     pub fn ldrbt(_emulator: &mut Emulator, _instruction: u32) -> u32 {

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -565,9 +565,23 @@ pub mod instructions {
     pub fn ldrbt(_emulator: &mut Emulator, _instruction: u32) -> u32 {
         1
     }
-    pub fn ldrh(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Load register half-word
+    pub fn ldrh(emulator: &mut Emulator, instruction: u32) -> u32 {
+        misc_load_store_instruction_wrapper(
+            emulator,
+            instruction,
+            |emulator, destination_register, address| {
+                let value = read_half_word(emulator, address);
+                emulator
+                    .cpu
+                    .set_register_value(destination_register, value as u32);
+            },
+        );
+
         1
     }
+
     pub fn ldrsb(_emulator: &mut Emulator, _instruction: u32) -> u32 {
         1
     }

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -613,9 +613,26 @@ pub mod instructions {
 
         1
     }
-    pub fn ldrt(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+
+    /// Load register with translation
+    pub fn ldrt(emulator: &mut Emulator, instruction: u32) -> u32 {
+        /*
+        MemoryAccess(B-bit, E-bit)
+        if ConditionPassed(cond) then
+            Rd = Memory[address,4] Rotate_Right (8 * address[1:0])
+        */
+
+        debug_assert_ne!(
+            RegisterNames::try_from(instruction >> 12 & 0xf).unwrap(),
+            r15,
+            "LDRT: result is unpredictable if r15 is specified for destination register"
+        );
+
+        load_store_instruction_wrapper(emulator, instruction, load_register);
+
         1
     }
+
     pub fn mcr(_emulator: &mut Emulator, _instruction: u32) -> u32 {
         1
     }

--- a/packages/lavender-core/src/emulator/armv4t/arm.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm.rs
@@ -582,7 +582,19 @@ pub mod instructions {
         1
     }
 
-    pub fn ldrsb(_emulator: &mut Emulator, _instruction: u32) -> u32 {
+    /// Load register signed byte
+    pub fn ldrsb(emulator: &mut Emulator, instruction: u32) -> u32 {
+        misc_load_store_instruction_wrapper(
+            emulator,
+            instruction,
+            |emulator, destination_register, address| {
+                let value = (read_byte(emulator, address) as i32) << 24 >> 24;
+                emulator
+                    .cpu
+                    .set_register_value(destination_register, value as u32);
+            },
+        );
+
         1
     }
     pub fn ldrsh(_emulator: &mut Emulator, _instruction: u32) -> u32 {

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -275,6 +275,24 @@ fn decode_ldrbt() {
 }
 
 #[test]
+fn behavior_ldrbt() {
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0000, 0xaabb_ccdd);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0100_1111_0010_0001_0000_0000_0101 - ldrbt r1,[r2],0x5
+        process_instruction(&mut emulator, 0xE4F2_1005);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xdd);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0005);
+    }
+}
+
+#[test]
 fn decode_ldrh() {
     assert_eq!(decode_instruction(0x0_05_000_b_0) as usize, ldrh as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -257,6 +257,53 @@ fn decode_str() {
 }
 
 #[test]
+fn behavior_str() {
+    // Offset
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xaaaa_aaaa);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_1000_0010_0001_0000_0000_1011 - str r1,[r2,0x00B]
+        process_instruction(&mut emulator, 0xE582_100B);
+
+        assert_eq!(emulator.memory.read_word(0x0300_0008), 0xaaaa_aaaa);
+    }
+
+    // Pre-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xcccc_cccc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_1010_0010_0001_0000_0000_1011 - str r1,[r2,0x00B]!
+        process_instruction(&mut emulator, 0xE5A2_100B);
+
+        assert_eq!(emulator.memory.read_word(0x0300_0008), 0xcccc_cccc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_000B);
+    }
+
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xbbbb_bbbb);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0100_1000_0010_0001_0000_0000_1011 - str r1,[r2],0x00B
+        process_instruction(&mut emulator, 0xE482_100B);
+
+        assert_eq!(emulator.memory.read_word(0x0300_0000), 0xbbbb_bbbb);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_000B);
+    }
+}
+
+#[test]
 fn decode_strb() {
     assert_eq!(decode_instruction(0x0_44_000_0_0) as usize, strb as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -399,6 +399,68 @@ fn decode_ldrsh() {
 }
 
 #[test]
+fn behavior_ldrsh() {
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1101_0010_0001_0000_1111_0100 - ldrsh r1,[r2,0x4]
+        process_instruction(&mut emulator, 0xE1D2_10F4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xffff_bbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0000);
+    }
+
+    // Pre-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1111_0010_0001_0000_1111_0100 - ldrsh r1,[r2,0x4]!
+        process_instruction(&mut emulator, 0xE1F2_10F4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xffff_bbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0000, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0000_1101_0010_0001_0000_1111_0100 - ldrsh r1,[r2],0x4
+        process_instruction(&mut emulator, 0xE0D2_10F4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xffff_bbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+
+    // Offset with a positive byte value
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_7fff);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1101_0010_0001_0000_1111_0100 - ldrsh r1,[r2,0x4]
+        process_instruction(&mut emulator, 0xE1D2_10F4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x7fff);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0000);
+    }
+}
+
+#[test]
 fn decode_ldrt() {
     assert_eq!(decode_instruction(0x0_43_000_0_0) as usize, ldrt as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -665,6 +665,26 @@ fn decode_strbt() {
 }
 
 #[test]
+fn behavior_strbt() {
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xffff_ffbb);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0100_1110_0010_0001_0000_0000_0101 - strbt r1,[r2],0x5
+        process_instruction(&mut emulator, 0xE4E2_1005);
+
+        assert_eq!(emulator.memory.read_byte(0x0300_0000), 0xbb);
+        assert_eq!(emulator.memory.read_byte(0x0300_0001), 0x0);
+
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0005);
+    }
+}
+
+#[test]
 fn decode_strh() {
     assert_eq!(decode_instruction(0x0_00_000_b_0) as usize, strh as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -332,6 +332,68 @@ fn decode_ldrsb() {
 }
 
 #[test]
+fn behavior_ldrsb() {
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1101_0010_0001_0000_1101_0100 - ldrsb r1,[r2,0x4]
+        process_instruction(&mut emulator, 0xE1D2_10D4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xffff_ffcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0000);
+    }
+
+    // Pre-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1111_0010_0001_0000_1101_0100 - ldrsb r1,[r2,0x4]!
+        process_instruction(&mut emulator, 0xE1F2_10D4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xffff_ffcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0000, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0000_1101_0010_0001_0000_1101_0100 - ldrsb r1,[r2],0x4
+        process_instruction(&mut emulator, 0xE0D2_10D4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xffff_ffcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+
+    // Offset with a positive byte value
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_bb7f);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1101_0010_0001_0000_1101_0100 - ldrsb r1,[r2,0x4]
+        process_instruction(&mut emulator, 0xE1D2_10D4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x7f);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0000);
+    }
+}
+
+#[test]
 fn decode_ldrsh() {
     assert_eq!(decode_instruction(0x0_05_000_f_0) as usize, ldrsh as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -499,6 +499,51 @@ fn decode_strh() {
 }
 
 #[test]
+fn behavior_strh() {
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1100_0010_0001_0000_1011_0100 - strh r1,[r2,0x4]
+        process_instruction(&mut emulator, 0xE1C2_10B4);
+        assert_eq!(emulator.memory.read_half_word(0x0300_0004), 0xbbcc);
+    }
+
+    // Pre-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1110_0010_0001_0000_1011_0100 - strh r1,[r2,0x4]!
+        process_instruction(&mut emulator, 0xE1E2_10B4);
+
+        assert_eq!(emulator.memory.read_half_word(0x0300_0004), 0xbbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0000_1100_0010_0001_0000_1011_0100 - strh r1,[r2],0x4
+        process_instruction(&mut emulator, 0xE0C2_10B4);
+
+        assert_eq!(emulator.memory.read_half_word(0x0300_0000), 0xbbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+}
+
+#[test]
 fn decode_strt() {
     assert_eq!(decode_instruction(0x0_42_000_0_0) as usize, strt as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -223,6 +223,53 @@ fn decode_ldrb() {
 }
 
 #[test]
+fn behavior_ldrb() {
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0008, 0xaabb_ccdd);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_1101_0010_0001_0000_0000_1010 - ldrb r1,[r2,0x00A]
+        process_instruction(&mut emulator, 0xE5D2_100A);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xbb);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0000);
+    }
+
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0000, 0xaabb_ccdd);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0100_1101_0010_0001_0000_0000_0101 - ldrb r1,[r2],0x5
+        process_instruction(&mut emulator, 0xE4D2_1005);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xdd);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0005);
+    }
+
+    // Pre-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0010, 0xaabb_ccdd);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_1111_0010_0001_0000_0001_0000 - ldrb r1,[r2,0x10]!
+        process_instruction(&mut emulator, 0xE5F2_1010);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xdd);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0010);
+    }
+}
+
+#[test]
 fn decode_ldrbt() {
     assert_eq!(decode_instruction(0x0_47_000_0_0) as usize, ldrbt as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -720,6 +720,24 @@ fn decode_strt() {
 }
 
 #[test]
+fn behavior_strt() {
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.cpu.set_register_value(r1, 0xbbbb_bbbb);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0100_1010_0010_0001_0000_0000_1011 - strt r1,[r2],0xB
+        process_instruction(&mut emulator, 0xE4A2_100B);
+
+        assert_eq!(emulator.memory.read_word(0x0300_0000), 0xbbbb_bbbb);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_000B);
+    }
+}
+
+#[test]
 fn decode_sub() {
     assert_eq!(decode_instruction(0x0_04_000_0_0) as usize, sub as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/arm_tests.rs
@@ -280,6 +280,53 @@ fn decode_ldrh() {
 }
 
 #[test]
+fn behavior_ldrh() {
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1101_0010_0001_0000_1011_0100 - ldrh r1,[r2,0x4]
+        process_instruction(&mut emulator, 0xE1D2_10B4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xbbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0000);
+    }
+
+    // Pre-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0004, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0001_1111_0010_0001_0000_1011_0100 - ldrh r1,[r2,0x4]!
+        process_instruction(&mut emulator, 0xE1F2_10B4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xbbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+
+    // Post-indexed
+    {
+        let mut emulator = Emulator::dummy();
+
+        emulator.memory.write_word(0x0300_0000, 0xaaaa_bbcc);
+        emulator.cpu.set_register_value(r2, 0x0300_0000);
+
+        //   cond    P UBWL Rn   Rd   addr      addr
+        // 0b1110_0000_1101_0010_0001_0000_1011_0100 - ldrh r1,[r2],0x4
+        process_instruction(&mut emulator, 0xE0D2_10B4);
+
+        assert_eq!(emulator.cpu.get_register_value(r1), 0xbbcc);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0300_0004);
+    }
+}
+
+#[test]
 fn decode_ldrsb() {
     assert_eq!(decode_instruction(0x0_05_000_d_0) as usize, ldrsb as usize);
 }

--- a/packages/lavender-core/src/emulator/armv4t/mod.rs
+++ b/packages/lavender-core/src/emulator/armv4t/mod.rs
@@ -10,3 +10,5 @@ pub mod utils;
 mod arm_tests;
 #[cfg(test)]
 mod thumb_tests;
+#[cfg(test)]
+mod utils_tests;

--- a/packages/lavender-core/src/emulator/armv4t/utils.rs
+++ b/packages/lavender-core/src/emulator/armv4t/utils.rs
@@ -54,8 +54,79 @@ pub fn process_shifter_operand(emulator: &mut Emulator, instruction: u32) -> u32
     }
 }
 
-pub fn process_addressing_mode(emulator: &mut Emulator, instruction: u32) -> u32 {
-    0x0800_0000
+pub fn process_addressing_mode(emulator: &mut Emulator, instruction: u32) -> (u32, AddressingType) {
+    let is_immediate_value = instruction >> 25 & 1 == 0;
+
+    let post_index_addressing = instruction >> 24 & 1 == 0;
+
+    // In post indexed addressing mode this would indicate that we're dealing with a T version of
+    // the instruction (with Translation). These are usually used in privileged mode to emulate
+    // user mode memory accesses. If that's the case then we can just ignore it.
+    // In pre indexed mode this indicates whether we'll write the calculated memory address back to
+    // the base register.
+    let write_address_to_base_register = instruction >> 21 & 1 == 1;
+
+    let base_register = RegisterNames::try_from(instruction >> 16 & 0xf).unwrap();
+    let base_register_value = emulator.cpu.get_register_value(base_register);
+
+    let add_offset = instruction >> 23 & 1 == 1;
+
+    let offset = if is_immediate_value {
+        instruction & 0xfff
+    } else {
+        let shift_mode = instruction >> 5 & 0x3;
+        let register_value = emulator
+            .cpu
+            .get_register_value(RegisterNames::try_from(instruction & 0xf).unwrap());
+
+        let shift_imm = instruction >> 7 & 0x1f;
+
+        match (shift_mode, shift_imm) {
+            (0, 0) => register_value,
+            (0, _) => register_value << shift_imm,
+            (1, 0) => 0,
+            (1, _) => register_value >> shift_imm,
+            (2, 0) => {
+                (if register_value & 0x8000_0000 == 0x8000_0000 {
+                    0xFFFF_FFFF
+                } else {
+                    0x0
+                })
+            }
+            // Shift operations on signed integers always perform an arithmetic shift in Rust
+            (2, _) => ((register_value as i32) >> shift_imm) as u32,
+            (3, 0) => (if emulator.cpu.get_c() { 1 << 31 } else { 0 }) | (register_value >> 1),
+            (3, _) => register_value.rotate_right(shift_imm),
+            (_, _) => panic!("Shift mode not matched for shifter_operand."),
+        }
+    };
+
+    let (address, _) = if add_offset {
+        base_register_value.overflowing_add(offset)
+    } else {
+        base_register_value.overflowing_sub(offset)
+    };
+
+    if post_index_addressing {
+        let temporary = emulator.cpu.get_register_value(base_register);
+
+        // Write the calculated address back into the base register
+        emulator.cpu.set_register_value(base_register, address);
+
+        (temporary, AddressingType::PostIndexed)
+    } else {
+        let addressing_type = if write_address_to_base_register {
+            // This should only run if the instruction condition passes, but we should never be here if
+            // it doesn't so.. don't do anything special
+            emulator.cpu.set_register_value(base_register, address);
+
+            AddressingType::PreIndexed
+        } else {
+            AddressingType::Offset
+        };
+
+        (address, addressing_type)
+    }
 }
 
 pub fn get_data_processing_operands(

--- a/packages/lavender-core/src/emulator/armv4t/utils_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/utils_tests.rs
@@ -307,3 +307,112 @@ fn test_addressing_mode_2_scaled_register_preindexed_lsl() {
         assert_eq!(emulator.cpu.get_register_value(r2), 0x0000_0001);
     }
 }
+
+#[test]
+fn test_addressing_mode_3_immediate_offset() {
+    let mut emulator = Emulator::dummy();
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+
+        //   cond    P U WL Rn   Rd   immH  SH  immL
+        // 0b1110_0001_1101_0001_0010_1000_1011_0001 - ldrh r2,[r1,0x81]
+        let (address, addressing_type) = process_misc_addressing_mode(&mut emulator, 0xE1D1_28B1);
+        assert_eq!(address, 0x4000_0081);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+    }
+
+    // Substract offset
+    {
+        //   cond    P U WL Rn   Rd   immH  SH  immL
+        // 0b1110_0001_0101_0001_0010_1000_1011_0001 - ldrh r2,[r1,-0x81]
+        let (address, addressing_type) = process_misc_addressing_mode(&mut emulator, 0xE151_28B1);
+        assert_eq!(address, 0x3FFF_FF7F);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+    }
+}
+
+#[test]
+fn test_addressing_mode_3_register_offset() {
+    let mut emulator = Emulator::dummy();
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+        emulator.cpu.set_register_value(r3, 0x1000_0000);
+
+        //   cond    P U WL Rn   Rd   SBZ   SH  Rm
+        // 0b1110_0001_1001_0001_0010_0000_1011_0011 - ldrh r2,[r1,r3]
+        let (address, addressing_type) = process_misc_addressing_mode(&mut emulator, 0xE191_20B3);
+        assert_eq!(address, 0x5000_0000);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+    }
+}
+
+#[test]
+fn test_addressing_mode_3_immediate_preindexed() {
+    let mut emulator = Emulator::dummy();
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+
+        //   cond    P U WL Rn   Rd   immH  SH  Rm
+        // 0b1110_0001_1111_0001_0010_1000_1011_0001 - ldrh r2,[r1,0x81]!
+        let (address, addressing_type) = process_misc_addressing_mode(&mut emulator, 0xE1F1_28B1);
+        assert_eq!(address, 0x4000_0081);
+        assert_eq!(addressing_type, AddressingType::PreIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0081);
+    }
+}
+
+#[test]
+fn test_addressing_mode_3_register_preindexed() {
+    let mut emulator = Emulator::dummy();
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+        emulator.cpu.set_register_value(r3, 0x1000_0000);
+
+        //   cond    P U WL Rn   Rd   SBZ   SH  Rm
+        // 0b1110_0001_1011_0001_0010_0000_1011_0011 - ldrh r2,[r1,r3]!
+        let (address, addressing_type) = process_misc_addressing_mode(&mut emulator, 0xE1B1_20B3);
+        assert_eq!(address, 0x5000_0000);
+        assert_eq!(addressing_type, AddressingType::PreIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x5000_0000);
+    }
+}
+
+#[test]
+fn test_addressing_mode_3_immediate_postindexed() {
+    let mut emulator = Emulator::dummy();
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+
+        //   cond    P U WL Rn   Rd   immH  SH  Rm
+        // 0b1110_0000_1101_0001_0010_1000_1011_0001 - ldrh r2,[r1],0x81
+        let (address, addressing_type) = process_misc_addressing_mode(&mut emulator, 0xE0D1_28B1);
+        assert_eq!(address, 0x4000_0000);
+        assert_eq!(addressing_type, AddressingType::PostIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0081);
+    }
+}
+
+#[test]
+fn test_addressing_mode_3_register_postindexed() {
+    let mut emulator = Emulator::dummy();
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+        emulator.cpu.set_register_value(r3, 0x1000_0000);
+
+        //   cond    P U WL Rn   Rd   SBZ   SH  Rm
+        // 0b1110_0000_1001_0001_0010_0000_1011_0011 - ldrh r2,[r1],r3
+        let (address, addressing_type) = process_misc_addressing_mode(&mut emulator, 0xE091_20B3);
+        assert_eq!(address, 0x4000_0000);
+        assert_eq!(addressing_type, AddressingType::PostIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x5000_0000);
+    }
+}

--- a/packages/lavender-core/src/emulator/armv4t/utils_tests.rs
+++ b/packages/lavender-core/src/emulator/armv4t/utils_tests.rs
@@ -1,0 +1,309 @@
+use crate::emulator::{armv4t::utils::*, cpu::RegisterNames::*, Emulator};
+
+#[test]
+fn test_addressing_mode_2_immediate_offset() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r1, 0x4000_0000);
+
+    // Add offset to base register value
+    {
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_1001_0001_0011_1000_0000_0001 - ldr r3,[r1,0x801]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE591_3801);
+        assert_eq!(address, 0x4000_0801);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+    }
+
+    // Substract offset from base register value
+    {
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_0001_0001_0011_1000_0000_0001 - ldr r3,[r1,-0x801]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE511_3801);
+        assert_eq!(address, 0x3FFF_F7FF);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_immediate_postindexed() {
+    let mut emulator = Emulator::dummy();
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0100_1001_0001_0011_1000_0000_0001 - ldr r3,[r1],0x801
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE491_3801);
+        assert_eq!(address, 0x4000_0000);
+        assert_eq!(addressing_type, AddressingType::PostIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0801);
+    }
+
+    // Substract offset
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0100_0001_0001_0011_1000_0000_0001 - ldr r3,[r1],-0x801
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE411_3801);
+        assert_eq!(address, 0x4000_0000);
+        assert_eq!(addressing_type, AddressingType::PostIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x3FFF_F7FF);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_immediate_preindexed() {
+    let mut emulator = Emulator::dummy();
+
+    // Add offset
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_1011_0001_0011_1000_0000_0001 - ldr r3,[r1,0x801]!
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE5B1_3801);
+        assert_eq!(address, 0x4000_0801);
+        assert_eq!(addressing_type, AddressingType::PreIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0801);
+    }
+
+    // Substract offset
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+        //   cond    P UBWL Rn   Rd   offset12
+        // 0b1110_0101_0011_0001_0011_1000_0000_0001 - ldr r3,[r1,-0x801]!
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE531_3801);
+        assert_eq!(address, 0x3FFF_F7FF);
+        assert_eq!(addressing_type, AddressingType::PreIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x3FFF_F7FF);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_register_offset() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r1, 0x4000_0000);
+    emulator.cpu.set_register_value(r2, 0x1000_0001);
+
+    // Add offset
+    {
+        //   cond    P UBWL Rn   Rd   SBZ       Rm
+        // 0b1110_0111_1001_0001_0011_0000_0000_0001 - ldr r3,[r1,r2]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3002);
+        assert_eq!(address, 0x5000_0001);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x1000_0001);
+    }
+
+    // Substract offset
+    {
+        //   cond    P UBWL Rn   Rd   SBZ       Rm
+        // 0b1110_0111_0001_0001_0011_0000_0000_0001 - ldr r3,[r1,-r2]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE711_3002);
+        assert_eq!(address, 0x2FFF_FFFF);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x1000_0001);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_register_preindexed() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r2, 0x1000_0001);
+
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+        //   cond    P UBWL Rn   Rd   SBZ       Rm
+        // 0b1110_0111_1011_0001_0011_0000_0000_0010 - ldr r3,[r1,r2]!
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE7B1_3002);
+        assert_eq!(address, 0x5000_0001);
+        assert_eq!(addressing_type, AddressingType::PreIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x5000_0001);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x1000_0001);
+    }
+
+    // Substract offset
+    {
+        emulator.cpu.set_register_value(r1, 0x4000_0000);
+        //   cond    P UBWL Rn   Rd   SBZ       Rm
+        // 0b1110_0111_0011_0001_0011_0000_0000_0010 - ldr r3,[r1,-r2]!
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE731_3002);
+        assert_eq!(address, 0x2FFF_FFFF);
+        assert_eq!(addressing_type, AddressingType::PreIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x2FFF_FFFF);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x1000_0001);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_scaled_register_offset_asr() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r1, 0x4000_0000);
+    emulator.cpu.set_register_value(r2, 0x8000_0000);
+
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_11110_10_0_0010 - ldr r3,[r1,r2,asr 0x1E]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3F42);
+        assert_eq!(address, 0x3FFF_FFFE);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x8000_0000);
+    }
+
+    // Special case when shift_imm == 0 and Rm contains a negative number
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_00000_10_0_0010 - ldr r3,[r1,r2,asr 0x20]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3042);
+        assert_eq!(address, 0x3FFF_FFFF);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x8000_0000);
+    }
+
+    // Special case when shift_imm == 0 and Rm contains a positive number
+    {
+        emulator.cpu.set_register_value(r2, 0x7FFF_FFFF);
+
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_00000_10_0_0010 - ldr r3,[r1,r2,asr 0x20]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3042);
+        assert_eq!(address, 0x4000_0000);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x7FFF_FFFF);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_scaled_register_offset_lsl() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r1, 0x4000_0000);
+    emulator.cpu.set_register_value(r2, 0x0000_0001);
+
+    // Add offset
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_11100_00_0_0010 - ldr r3,[r1,r2,lsl 0x1C]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3E02);
+        assert_eq!(address, 0x5000_0000);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0000_0001);
+    }
+
+    // Substract offset
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_0001_0001_0011_11100_00_0_0010 - ldr r3,[r1,-r2,lsl 0x1C]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE711_3E02);
+        assert_eq!(address, 0x3000_0000);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0000_0001);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_scaled_register_offset_lsr() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r1, 0x4000_0000);
+    emulator.cpu.set_register_value(r2, 0x8000_0000);
+
+    // Add offset
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_00011_01_0_0010 - ldr r3,[r1,r2,lsr 0x3]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_31A2);
+        assert_eq!(address, 0x5000_0000);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x8000_0000);
+    }
+
+    // Special case when shift_imm == 0 (i.e. "32 bit shift")
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_00000_01_0_0010 - ldr r3,[r1,r2,lsr 0x20]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3022);
+        assert_eq!(address, 0x4000_0000);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x8000_0000);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_scaled_register_offset_ror_rrx() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r1, 0x4000_0000);
+    emulator.cpu.set_register_value(r2, 0x0001_1000);
+
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_10000_11_0_0010 - ldr r3,[r1,r2,ror 0x10]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3862);
+        assert_eq!(address, 0x5000_0001);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0001_1000);
+    }
+
+    // Special case when shift_imm == 0 and C flag is set
+    {
+        emulator.cpu.set_nzcv(false, false, true, false);
+        emulator.cpu.set_register_value(r2, 0x2);
+
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_00000_11_0_0010 - ldr r3,[r1,r2,rrx 0x1]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3062);
+        assert_eq!(address, 0xC000_0001);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x2);
+    }
+
+    // Special case when shift_imm == 0 and C flag is not set
+    {
+        emulator.cpu.set_nzcv(false, false, false, false);
+        emulator.cpu.set_register_value(r2, 0x2);
+
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1001_0001_0011_00000_11_0_0010 - ldr r3,[r1,r2,rrx 0x1]
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE791_3062);
+        assert_eq!(address, 0x4000_0001);
+        assert_eq!(addressing_type, AddressingType::Offset);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x4000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x2);
+    }
+}
+
+#[test]
+fn test_addressing_mode_2_scaled_register_preindexed_lsl() {
+    let mut emulator = Emulator::dummy();
+
+    emulator.cpu.set_register_value(r1, 0x4000_0000);
+    emulator.cpu.set_register_value(r2, 0x0000_0001);
+
+    {
+        //   cond    P UBWL Rn   Rd   Imm   Sh   Rm
+        // 0b1110_0111_1011_0001_0011_11100_00_0_0010 - ldr r3,[r1,r2,lsl 0x1C]!
+        let (address, addressing_type) = process_addressing_mode(&mut emulator, 0xE7B1_3E02);
+        assert_eq!(address, 0x5000_0000);
+        assert_eq!(addressing_type, AddressingType::PreIndexed);
+        assert_eq!(emulator.cpu.get_register_value(r1), 0x5000_0000);
+        assert_eq!(emulator.cpu.get_register_value(r2), 0x0000_0001);
+    }
+}


### PR DESCRIPTION
This should contain impls for all the loads and stores. Or at least the ones that are supported by addressing modes 2 and 3.

It all still feels a bit messy but I'm at least confident that the unit tests are correct, although, they don't test every scenario imaginable, certainly not the debug panics...

Some of the more worrying bits would be:
* not sure where the `internal` module fits into, bit of an ad-hoc addition
* `debug_assert`'s, maybe they'll be useful early on but can see them thrown away due to being annoying quickly 😂 
* behaviour tests doing multiple things which results in needing an extra step when finding out what went wrong
* lots of "nested" function calls in load/store instructions, didn't want to mess with macros just yet

Also, this PR ended up being way too large, so, sorry about that 😁 